### PR TITLE
fix: use per-branch cross-reference tracking to expand sibling fields independently

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -54,7 +54,9 @@ export const generateQuery = ({
 		if (curType.getFields) {
 			const crossReferenceKey = `${parentName}To${field.name}Key`;
 			if (crossReferenceKeyList.indexOf(crossReferenceKey) !== -1 || curDepth > depthLimit) return '';
-			crossReferenceKeyList.push(crossReferenceKey);
+			// Use a per-branch copy so sibling fields that reference the same
+			// type are each expanded independently (fixes #69).
+			crossReferenceKeyList = [...crossReferenceKeyList, crossReferenceKey];
 			const children = curType.getFields();
 			childQuery = Object.entries(children);
 			if (skeleton && typeof skeleton === 'object') {

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -143,6 +143,45 @@ exports[`check field generator with skeleton 1`] = `
 
 exports[`check warnings for no mutations, query, subscription in schema 1`] = `{}`;
 
+exports[`should expand sibling fields that reference the same type independently (issue #69) 1`] = `
+"query order($id: Int!){
+    order(id: $id){
+        payment{
+            id
+            user{
+                id
+                fcmTokens{
+                    token
+                    lastSeen
+                }
+                invoiceAddress{
+                    customerName
+                    country
+                    city
+                    streetAddress
+                }
+            }
+        }
+        tipPayment{
+            id
+            user{
+                id
+                fcmTokens{
+                    token
+                    lastSeen
+                }
+                invoiceAddress{
+                    customerName
+                    country
+                    city
+                    streetAddress
+                }
+            }
+        }
+    }
+}"
+`;
+
 exports[`should return field name when field has no type (type is undefined) 1`] = `
 "query untypedField{
     untypedField

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,11 +1,13 @@
 require('graphql-import-node');
 const typeDefs = require('./schemas/sampleTypeDef.graphql');
 const typeDefsWithoutMutation = require('./schemas/empty.graphql');
+const crossRefTypeDefs = require('./schemas/crossRefTypeDef.graphql');
 const makeExecutableSchema = require('graphql-tools').makeExecutableSchema;
 require('should');
 
 const schema = makeExecutableSchema({ typeDefs });
 const schemaWithoutMutation = makeExecutableSchema({ typeDefs: typeDefsWithoutMutation });
+const crossRefSchema = makeExecutableSchema({ typeDefs: crossRefTypeDefs });
 import { generateAll, generateQuery } from "../src";
 
 it('validate generated queries', async () => {
@@ -162,6 +164,16 @@ it('should return field name when field has no type (type is undefined)', async 
 				name: 'untypedField',
 				args: []
 			}
+		})
+	).toMatchSnapshot()
+);
+
+it('should expand sibling fields that reference the same type independently (issue #69)', async () =>
+	expect(
+		generateQuery({
+			field: crossRefSchema
+				.getQueryType()
+				.getFields().order
 		})
 	).toMatchSnapshot()
 );

--- a/test/schemas/crossRefTypeDef.graphql
+++ b/test/schemas/crossRefTypeDef.graphql
@@ -1,0 +1,31 @@
+type Query {
+    order(id: Int!): OrderDTO!
+}
+
+type OrderDTO {
+    payment: PaymentDTO!
+    tipPayment: PaymentDTO!
+}
+
+type PaymentDTO {
+    id: Float!
+    user: User!
+}
+
+type User {
+    id: Int!
+    fcmTokens: [FCMToken!]
+    invoiceAddress: UserInvoiceAddressInput
+}
+
+type FCMToken {
+    token: String!
+    lastSeen: String!
+}
+
+type UserInvoiceAddressInput {
+    customerName: String!
+    country: String!
+    city: String!
+    streetAddress: String!
+}


### PR DESCRIPTION
## Problem

Fixes #69 — Faulty cross-reference detection.

When two fields reference the same type (e.g. `payment` and `tipPayment` both referencing `PaymentDTO`), the second field was silently collapsed because `crossReferenceKeyList` was shared as a mutable array across all branches.

## Solution

Changed `crossReferenceKeyList` from a shared mutable array to per-branch copies (using spread/slice). Each field now gets its own tracking list, so sibling fields referencing the same type are all fully expanded independently.

## Testing

- 14/14 existing tests pass
- New test case + snapshot added for the cross-reference scenario